### PR TITLE
fix: remove unnecessary context menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,12 +14,6 @@
 </head>
 
 <body class="min-w-full min-h-screen dark:bg-gray-700 bg-white overflow-hidden">
-  <!-- Context menu for bookmarks -->
-  <div id="bookmarksMenu" class="hidden">
-    <ul>
-      <li><a href="#">Remove bookmark</a></li>
-    </ul>
-  </div>
   <!-- Tab bar -->
   <div class="flex items-center px-4 py-2 mt-2 bg-white dark:bg-gray-700">
     <div id="tabs-bar" class="flex items-center flex-1 space-x-2 overflow-auto no-scrollbar">
@@ -53,7 +47,7 @@
         src="../assets/icons/gear-fill.svg" alt="Settings"></button>
   </div>
   <!-- Bookmarks -->
-  <div id="bookmarks" class="flex px-4 py-2 bg-white dark:bg-gray-700">
+  <div id="bookmarks" class="flex items-center flex-1 space-x-2 overflow-auto no-scrollbar">
     <!-- bookmarks inserted with JS -->
   </div>
   <!-- Preferences -->

--- a/src/index.html
+++ b/src/index.html
@@ -47,7 +47,7 @@
         src="../assets/icons/gear-fill.svg" alt="Settings"></button>
   </div>
   <!-- Bookmarks -->
-  <div id="bookmarks" class="flex items-center flex-1 space-x-2 overflow-auto no-scrollbar">
+  <div id="bookmarks" class="flex px-4 py-2 bg-white dark:bg-gray-700">
     <!-- bookmarks inserted with JS -->
   </div>
   <!-- Preferences -->


### PR DESCRIPTION
I was working on a context menu earlier and then decided not to use it. Forgot to remove the HTML.