### PR TITLE
Remove rule 3 (it’s just a dupe)

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -3,6 +3,5 @@ While contributing with PRs and Commits, please make sure to follow the followin
 ## Rules
 1. Don't make fights in PRs.
 2. Make sure to be ready to actively answer questions about your PRs. 
-3. Please do not put empty descriptions in your PRs.
-4. Don't put empty descriptions in your PRs, also when making commits edit the commit name to reflect what the commit is and contains.
+3. Don't put empty descriptions in your PRs, also when making commits edit the commit name to reflect what the commit is and contains.
 ## Please contribute to this file.


### PR DESCRIPTION
In the contributing guidelines, Rule 3 just says a part of rule 4.