### PR TITLE
Add Escosia Support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -85,6 +85,7 @@
                     <option value="1">DuckDuckGo</option>
                     <option value="2">Bing</option>
                     <option value="3">Brave</option>
+                    <option value="4">Escosia</option>
                 </select>
             </div>
             <div class="hidden" id="advanced">
@@ -107,6 +108,7 @@
                         <option value="1">DuckDuckGo</option>
                         <option value="2">Bing</option>
                         <option value="3">Brave</option>
+                        <option value="4">Escosia</option>
                     </select>
                 </div>
                 <div class="hidden" id="advanced">

--- a/src/search.js
+++ b/src/search.js
@@ -3,7 +3,8 @@ const engineurls = [
     'https://www.google.com/search?q=',
     'https://duckduckgo.com/?q=',
     'https://www.bing.com/search?q=',
-    'https://search.brave.com/search?q='
+    'https://search.brave.com/search?q=',
+    'https://www.ecosia.org/search?method=index&q='
 ];
 
 // protocols


### PR DESCRIPTION
[Escosia ](https://www.ecosia.org/?c=en)is a search engine where every search you make helps plant trees around the world by using ad revenue to pay for the labor of planting trees. I think this would be a great addition to Catalyst, it would allow people to search safely and support charities. So this pr adds an option to the settings to turn on Esocsia.